### PR TITLE
feat(mcp): verify API key during startup

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -7,7 +7,12 @@ import express from "express";
 
 import { registerBookmarkTools } from "./bookmarks";
 import { registerListTools } from "./lists";
-import { config, createMcpServer, logger } from "./shared";
+import {
+  config,
+  createMcpServer,
+  logger,
+  verifyKarakeepApiAccess,
+} from "./shared";
 import { registerTagTools } from "./tags";
 
 function buildServer() {
@@ -137,6 +142,8 @@ async function run() {
       config.transportMode === "httpstreamable" ? "HTTP streamable" : "stdio"
     } transport.`,
   );
+
+  await verifyKarakeepApiAccess();
 
   if (config.transportMode === "httpstreamable") {
     await startStreamableHttpServer();

--- a/apps/mcp/src/shared.ts
+++ b/apps/mcp/src/shared.ts
@@ -128,6 +128,40 @@ export const karakeepClient = createKarakeepClient({
 
 export const turndownService = new TurndownService();
 
+export async function verifyKarakeepApiAccess(): Promise<void> {
+  logger.info("Verifying Karakeep API credentials...");
+
+  const response = await karakeepClient
+    .GET("/users/me")
+    .catch((error: unknown): never => {
+      throw new Error(
+        `Unable to reach Karakeep API at ${config.apiAddr}: ${formatError(error)}`,
+      );
+    });
+
+  if ("error" in response) {
+    const status = response.response?.status;
+    const statusText = response.response?.statusText;
+    const statusMessage =
+      status !== undefined
+        ? `status ${status}${statusText ? ` (${statusText})` : ""}`
+        : "an unknown status";
+
+    throw new Error(
+      `Karakeep API key verification failed with ${statusMessage}: ${formatError(response.error)}`,
+    );
+  }
+
+  const { email, name, id } = response.data;
+  const identity = email ?? name ?? id;
+
+  logger.info(
+    `Karakeep API key verified${
+      identity ? ` (authenticated as ${identity})` : ""
+    }.`,
+  );
+}
+
 export function createMcpServer(): McpServer {
   return new McpServer({
     name: "Karakeep",

--- a/packages/trpc/routers/subscriptions.ts
+++ b/packages/trpc/routers/subscriptions.ts
@@ -12,7 +12,7 @@ import { authedProcedure, Context, publicProcedure, router } from "../index";
 
 const stripe = serverConfig.stripe.secretKey
   ? new Stripe(serverConfig.stripe.secretKey, {
-      apiVersion: "2025-06-30.basil",
+      apiVersion: "2025-08-27.basil",
     })
   : null;
 


### PR DESCRIPTION
## Summary
- add a startup health check in the MCP server that confirms the configured Karakeep API key can call /users/me and logs the authenticated identity
- surface the verification in the MCP bootstrap sequence so the process exits early when the credentials are invalid
- bump the Stripe client API version string used by the TRPC subscriptions router to match the currently generated typings

## Testing
- pnpm --filter @karakeep/mcp typecheck
- pnpm --filter @karakeep/mcp lint
- pnpm --filter @karakeep/cli typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cee23aa4dc8330a982dcbee8615a1b