### PR TITLE
docs: add MCP build instructions

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -12,6 +12,29 @@ This is the Karakeep MCP server, which is a server that can be used to interact 
 
 Currently, the MCP server only exposes tools (no resources).
 
+## Building from source
+
+Build the MCP server locally from the repository root with pnpm:
+
+```bash
+pnpm install
+pnpm --filter @karakeep/mcp build
+pnpm --filter @karakeep/mcp run
+```
+
+The build step emits the executable at `apps/mcp/dist/index.js`. Before
+running the compiled binary (either via the `run` script or with
+`node apps/mcp/dist/index.js`), export the required API credentials and any
+transport overrides:
+
+```bash
+export KARAKEEP_API_ADDR="https://<YOUR_SERVER_ADDR>"
+export KARAKEEP_API_KEY="<YOUR_TOKEN>"
+# Optional transport configuration
+export KARAKEEP_MCP_TRANSPORT=HTTPstreamable
+export KARAKEEP_MCP_STREAM_PORT=3000
+```
+
 ## Usage with Claude Desktop (stdio transport)
 
 From NPM:

--- a/docs/docs/09-mcp.md
+++ b/docs/docs/09-mcp.md
@@ -11,6 +11,29 @@ Karakeep comes with a Model Context Protocol server that can be used to interact
 - Creating text and URL bookmarks
 
 
+## Building from source
+
+Build the MCP server locally from the repository root with pnpm:
+
+```bash
+pnpm install
+pnpm --filter @karakeep/mcp build
+pnpm --filter @karakeep/mcp run
+```
+
+The build step emits the executable at `apps/mcp/dist/index.js`. Before
+running the compiled binary (either via the `run` script or with
+`node apps/mcp/dist/index.js`), export the required API credentials and any
+transport overrides:
+
+```bash
+export KARAKEEP_API_ADDR="https://<YOUR_SERVER_ADDR>"
+export KARAKEEP_API_KEY="<YOUR_TOKEN>"
+# Optional transport configuration
+export KARAKEEP_MCP_TRANSPORT=HTTPstreamable
+export KARAKEEP_MCP_STREAM_PORT=3000
+```
+
 ## Usage with Claude Desktop (stdio transport)
 
 From NPM:

--- a/docs/versioned_docs/version-v0.27.0/09-mcp.md
+++ b/docs/versioned_docs/version-v0.27.0/09-mcp.md
@@ -11,6 +11,29 @@ Karakeep comes with a Model Context Protocol server that can be used to interact
 - Creating text and URL bookmarks
 
 
+## Building from source
+
+Build the MCP server locally from the repository root with pnpm:
+
+```bash
+pnpm install
+pnpm --filter @karakeep/mcp build
+pnpm --filter @karakeep/mcp run
+```
+
+The build step emits the executable at `apps/mcp/dist/index.js`. Before
+running the compiled binary (either via the `run` script or with
+`node apps/mcp/dist/index.js`), export the required API credentials and any
+transport overrides:
+
+```bash
+export KARAKEEP_API_ADDR="https://<YOUR_SERVER_ADDR>"
+export KARAKEEP_API_KEY="<YOUR_TOKEN>"
+# Optional transport configuration
+export KARAKEEP_MCP_TRANSPORT=HTTPstreamable
+export KARAKEEP_MCP_STREAM_PORT=3000
+```
+
 ## Usage with Claude Desktop (stdio transport)
 
 From NPM:


### PR DESCRIPTION
## Summary
- document how to build and run the MCP server from source in the main MCP docs and the package README
- call out the emitted dist/index.js artifact and the environment variables that must be exported before running

## Testing
- `turbo run --no-daemon typecheck lint format` *(fails: existing @karakeep/shared-react type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d26c24b6a48330bd381a67f972c756